### PR TITLE
Updated .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "parserOption": {
+  "parserOptions": {
     "ecmaVersion": 6,
     "ecmaFeatures": {
       "jsx": true


### PR DESCRIPTION
Was `parserOption` in line 2 before which was not compatible with ESlint version 4.3.0.
Now changed to `parserOptions`.